### PR TITLE
Fix Mermaid subgraph labels in ARCHITECTURE.md for GitHub rendering

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -197,12 +197,14 @@
 ### 8.1 システム構成図
 ```mermaid
 flowchart LR
-    subgraph FE[Frontend (別リポジトリ)]
+    %% FE: Frontend（別リポジトリ）
+    subgraph FE[Frontend]
       A[Admin Console]
       P[Portal Web]
     end
 
-    subgraph BE[manpower-blog Backend (Spring Boot 3)]
+    %% BE: manpower-blog Backend（Spring Boot 3）
+    subgraph BE[manpower-blog Backend]
       S[blog-starter]
       AA[blog-admin-api]
       PA[blog-portal-api]


### PR DESCRIPTION
### Motivation
- GitHub's Mermaid renderer can fail when `subgraph` labels contain parentheses or non-ASCII annotations, so the diagram titles were simplified while preserving explanatory context as comments.

### Description
- Replaced `subgraph FE[Frontend (別リポジトリ)]` with `subgraph FE[Frontend]` and `subgraph BE[manpower-blog Backend (Spring Boot 3)]` with `subgraph BE[manpower-blog Backend]`, and moved the removed context into Mermaid comments (`%%`) in `ARCHITECTURE.md`.

### Testing
- Ran `sed -n '1,220p' ARCHITECTURE.md` to inspect the file contents and it succeeded.
- Ran `rg -n "subgraph|%% FE|%% BE" ARCHITECTURE.md` to verify the new comments and simplified labels and it succeeded.
- Ran `nl -ba ARCHITECTURE.md | sed -n '194,214p'` to confirm the exact changed lines and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a58b9cd4c83259bf824d986ded4c5)