### PR TITLE
refactor: apply DDD layering to content Article module

### DIFF
--- a/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/application/dto/ArticleCreateReq.java
+++ b/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/application/dto/ArticleCreateReq.java
@@ -1,4 +1,4 @@
-package com.manpowergroup.springboot.springboot3web.content.dto;
+package com.manpowergroup.springboot.springboot3web.content.application.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/application/dto/ArticleQueryRequest.java
+++ b/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/application/dto/ArticleQueryRequest.java
@@ -1,4 +1,4 @@
-package com.manpowergroup.springboot.springboot3web.content.dto;
+package com.manpowergroup.springboot.springboot3web.content.application.dto;
 
 import com.manpowergroup.springboot.springboot3web.blog.common.dto.PageRequest;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/application/dto/ArticleUpdateReq.java
+++ b/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/application/dto/ArticleUpdateReq.java
@@ -1,4 +1,4 @@
-package com.manpowergroup.springboot.springboot3web.content.dto;
+package com.manpowergroup.springboot.springboot3web.content.application.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/application/service/ArticleService.java
+++ b/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/application/service/ArticleService.java
@@ -1,17 +1,15 @@
-package com.manpowergroup.springboot.springboot3web.content.service;
+package com.manpowergroup.springboot.springboot3web.content.application.service;
 
-import com.baomidou.mybatisplus.extension.service.IService;
 import com.manpowergroup.springboot.springboot3web.blog.common.dto.JoinPageResult;
-import com.manpowergroup.springboot.springboot3web.content.dto.ArticleCreateReq;
-import com.manpowergroup.springboot.springboot3web.content.dto.ArticleQueryRequest;
-import com.manpowergroup.springboot.springboot3web.content.dto.ArticleUpdateReq;
-import com.manpowergroup.springboot.springboot3web.content.entity.Article;
-import com.manpowergroup.springboot.springboot3web.content.vo.ArticleVo;
+import com.manpowergroup.springboot.springboot3web.content.application.dto.ArticleCreateReq;
+import com.manpowergroup.springboot.springboot3web.content.application.dto.ArticleQueryRequest;
+import com.manpowergroup.springboot.springboot3web.content.application.dto.ArticleUpdateReq;
+import com.manpowergroup.springboot.springboot3web.content.application.vo.ArticleVo;
 
 /**
  * 記事サービスインターフェース
  */
-public interface ArticleService extends IService<Article> {
+public interface ArticleService {
 
     /**
      * 記事一覧をページング形式で取得する

--- a/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/application/service/impl/ArticleServiceImpl.java
+++ b/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/application/service/impl/ArticleServiceImpl.java
@@ -1,17 +1,15 @@
-package com.manpowergroup.springboot.springboot3web.content.service.impl;
+package com.manpowergroup.springboot.springboot3web.content.application.service.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import com.manpowergroup.springboot.springboot3web.blog.common.dto.JoinPageResult;
 import com.manpowergroup.springboot.springboot3web.blog.common.enums.ErrorCode;
 import com.manpowergroup.springboot.springboot3web.blog.common.exception.BizException;
-import com.manpowergroup.springboot.springboot3web.content.dto.ArticleCreateReq;
-import com.manpowergroup.springboot.springboot3web.content.dto.ArticleQueryRequest;
-import com.manpowergroup.springboot.springboot3web.content.dto.ArticleUpdateReq;
-import com.manpowergroup.springboot.springboot3web.content.entity.Article;
-import com.manpowergroup.springboot.springboot3web.content.mapper.ArticleMapper;
-import com.manpowergroup.springboot.springboot3web.content.service.ArticleService;
-import com.manpowergroup.springboot.springboot3web.content.vo.ArticleVo;
-import lombok.RequiredArgsConstructor;
+import com.manpowergroup.springboot.springboot3web.content.domain.model.Article;
+import com.manpowergroup.springboot.springboot3web.content.domain.repository.ArticleRepository;
+import com.manpowergroup.springboot.springboot3web.content.application.dto.ArticleCreateReq;
+import com.manpowergroup.springboot.springboot3web.content.application.dto.ArticleQueryRequest;
+import com.manpowergroup.springboot.springboot3web.content.application.dto.ArticleUpdateReq;
+import com.manpowergroup.springboot.springboot3web.content.application.service.ArticleService;
+import com.manpowergroup.springboot.springboot3web.content.application.vo.ArticleVo;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
@@ -19,31 +17,33 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
-import static com.manpowergroup.springboot.springboot3web.blog.common.util.ServiceHelper.*;
+import static com.manpowergroup.springboot.springboot3web.blog.common.util.ServiceHelper.safePageNum;
+import static com.manpowergroup.springboot.springboot3web.blog.common.util.ServiceHelper.safePageSize;
 
 /**
  * 記事サービス実装クラス
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
-public class ArticleServiceImpl extends ServiceImpl<ArticleMapper, Article>
-        implements ArticleService {
+public class ArticleServiceImpl implements ArticleService {
+
+    private final ArticleRepository articleRepository;
+
+    public ArticleServiceImpl(ArticleRepository articleRepository) {
+        this.articleRepository = articleRepository;
+    }
 
     @Override
     @Transactional(readOnly = true)
     public JoinPageResult<ArticleVo> queryArticlePageVo(ArticleQueryRequest request) {
 
-        // ページングパラメータの補正
         var p = safePageNum(request.getPageNum());
         var s = safePageSize(request.getPageSize());
         var offset = (p - 1) * s;
 
-        // 一覧データおよび総件数の取得
-        var records = this.baseMapper.selectPageVo(request, offset, s);
-        var total = this.baseMapper.countJoin(request);
+        var records = articleRepository.selectPageVo(request, offset, s);
+        var total = articleRepository.countJoin(request);
 
-        // ページング結果を返却
         return JoinPageResult.of(records, total, p, s);
     }
 
@@ -52,7 +52,7 @@ public class ArticleServiceImpl extends ServiceImpl<ArticleMapper, Article>
     public ArticleVo getArticleVoById(Long id) {
 
         var article = Optional.ofNullable(id)
-                .map(this.baseMapper::selectById)
+                .map(articleRepository::findById)
                 .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND));
 
         ArticleVo vo = new ArticleVo();
@@ -70,7 +70,7 @@ public class ArticleServiceImpl extends ServiceImpl<ArticleMapper, Article>
         Article article = new Article();
         BeanUtils.copyProperties(safeReq, article);
 
-        boolean saved = this.save(article);
+        boolean saved = articleRepository.save(article);
         if (!saved) {
             throw new BizException(ErrorCode.SERVER_ERROR);
         }
@@ -87,7 +87,7 @@ public class ArticleServiceImpl extends ServiceImpl<ArticleMapper, Article>
         Article article = new Article();
         BeanUtils.copyProperties(safeReq, article);
 
-        boolean updated = this.updateById(article);
+        boolean updated = articleRepository.updateById(article);
         if (!updated) {
             throw new BizException(ErrorCode.SERVER_ERROR);
         }
@@ -101,7 +101,7 @@ public class ArticleServiceImpl extends ServiceImpl<ArticleMapper, Article>
         Optional.ofNullable(id)
                 .orElseThrow(() -> new BizException(ErrorCode.BAD_REQUEST));
 
-        boolean deleted = this.removeById(id);
+        boolean deleted = articleRepository.removeById(id);
         if (!deleted) {
             throw new BizException(ErrorCode.SERVER_ERROR);
         }

--- a/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/application/vo/ArticleVo.java
+++ b/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/application/vo/ArticleVo.java
@@ -1,4 +1,4 @@
-package com.manpowergroup.springboot.springboot3web.content.vo;
+package com.manpowergroup.springboot.springboot3web.content.application.vo;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/domain/model/Article.java
+++ b/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/domain/model/Article.java
@@ -1,11 +1,15 @@
-package com.manpowergroup.springboot.springboot3web.content.entity;
+package com.manpowergroup.springboot.springboot3web.content.domain.model;
 
-import com.baomidou.mybatisplus.annotation.*;
+import com.baomidou.mybatisplus.annotation.FieldFill;
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableLogic;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
 
 import java.io.Serializable;
 import java.time.LocalDateTime;
-
-import lombok.Data;
 
 /**
  * 記事エンティティ（t_content_article）

--- a/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/domain/repository/ArticleRepository.java
+++ b/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/domain/repository/ArticleRepository.java
@@ -1,0 +1,22 @@
+package com.manpowergroup.springboot.springboot3web.content.domain.repository;
+
+import com.manpowergroup.springboot.springboot3web.content.domain.model.Article;
+import com.manpowergroup.springboot.springboot3web.content.application.dto.ArticleQueryRequest;
+import com.manpowergroup.springboot.springboot3web.content.application.vo.ArticleVo;
+
+import java.util.List;
+
+public interface ArticleRepository {
+
+    List<ArticleVo> selectPageVo(ArticleQueryRequest request, Long offset, Long size);
+
+    Long countJoin(ArticleQueryRequest request);
+
+    Article findById(Long id);
+
+    boolean save(Article article);
+
+    boolean updateById(Article article);
+
+    boolean removeById(Long id);
+}

--- a/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/infrastructure/mapper/ArticleMapper.java
+++ b/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/infrastructure/mapper/ArticleMapper.java
@@ -1,9 +1,9 @@
-package com.manpowergroup.springboot.springboot3web.content.mapper;
+package com.manpowergroup.springboot.springboot3web.content.infrastructure.mapper;
 
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
-import com.manpowergroup.springboot.springboot3web.content.dto.ArticleQueryRequest;
-import com.manpowergroup.springboot.springboot3web.content.entity.Article;
-import com.manpowergroup.springboot.springboot3web.content.vo.ArticleVo;
+import com.manpowergroup.springboot.springboot3web.content.domain.model.Article;
+import com.manpowergroup.springboot.springboot3web.content.application.dto.ArticleQueryRequest;
+import com.manpowergroup.springboot.springboot3web.content.application.vo.ArticleVo;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
@@ -34,5 +34,4 @@ public interface ArticleMapper extends BaseMapper<Article> {
      * @return 件数
      */
     Long countJoin(@Param("req") ArticleQueryRequest request);
-
 }

--- a/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/infrastructure/repository/MybatisArticleRepository.java
+++ b/blog-module-content/src/main/java/com/manpowergroup/springboot/springboot3web/content/infrastructure/repository/MybatisArticleRepository.java
@@ -1,0 +1,50 @@
+package com.manpowergroup.springboot.springboot3web.content.infrastructure.repository;
+
+import com.manpowergroup.springboot.springboot3web.content.domain.model.Article;
+import com.manpowergroup.springboot.springboot3web.content.domain.repository.ArticleRepository;
+import com.manpowergroup.springboot.springboot3web.content.application.dto.ArticleQueryRequest;
+import com.manpowergroup.springboot.springboot3web.content.infrastructure.mapper.ArticleMapper;
+import com.manpowergroup.springboot.springboot3web.content.application.vo.ArticleVo;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class MybatisArticleRepository implements ArticleRepository {
+
+    private final ArticleMapper articleMapper;
+
+    public MybatisArticleRepository(ArticleMapper articleMapper) {
+        this.articleMapper = articleMapper;
+    }
+
+    @Override
+    public List<ArticleVo> selectPageVo(ArticleQueryRequest request, Long offset, Long size) {
+        return articleMapper.selectPageVo(request, offset, size);
+    }
+
+    @Override
+    public Long countJoin(ArticleQueryRequest request) {
+        return articleMapper.countJoin(request);
+    }
+
+    @Override
+    public Article findById(Long id) {
+        return articleMapper.selectById(id);
+    }
+
+    @Override
+    public boolean save(Article article) {
+        return articleMapper.insert(article) > 0;
+    }
+
+    @Override
+    public boolean updateById(Article article) {
+        return articleMapper.updateById(article) > 0;
+    }
+
+    @Override
+    public boolean removeById(Long id) {
+        return articleMapper.deleteById(id) > 0;
+    }
+}

--- a/blog-module-content/src/main/resources/mapper/ArticleMapper.xml
+++ b/blog-module-content/src/main/resources/mapper/ArticleMapper.xml
@@ -2,11 +2,11 @@
 <!DOCTYPE mapper
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.manpowergroup.springboot.springboot3web.content.mapper.ArticleMapper">
+<mapper namespace="com.manpowergroup.springboot.springboot3web.content.infrastructure.mapper.ArticleMapper">
 
     <!-- 基本結果マッピング -->
     <resultMap id="BaseResultMap"
-               type="com.manpowergroup.springboot.springboot3web.content.entity.Article">
+               type="com.manpowergroup.springboot.springboot3web.content.domain.model.Article">
         <id column="id" property="id"/>
         <result column="title" property="title"/>
         <result column="content" property="content"/>
@@ -23,7 +23,7 @@
 
     <!-- 記事一覧取得（ページング） -->
     <select id="selectPageVo"
-            resultType="com.manpowergroup.springboot.springboot3web.content.vo.ArticleVo">
+            resultType="com.manpowergroup.springboot.springboot3web.content.application.vo.ArticleVo">
 
         SELECT
         a.id,

--- a/blog-portal-api/src/main/java/com/manpowergroup/springboot/springboot3web/portal/article/ArticleCreateController.java
+++ b/blog-portal-api/src/main/java/com/manpowergroup/springboot/springboot3web/portal/article/ArticleCreateController.java
@@ -2,11 +2,11 @@ package com.manpowergroup.springboot.springboot3web.portal.article;
 
 import com.manpowergroup.springboot.springboot3web.blog.common.dto.JoinPageResult;
 import com.manpowergroup.springboot.springboot3web.blog.common.dto.Result;
-import com.manpowergroup.springboot.springboot3web.content.dto.ArticleCreateReq;
-import com.manpowergroup.springboot.springboot3web.content.dto.ArticleQueryRequest;
-import com.manpowergroup.springboot.springboot3web.content.dto.ArticleUpdateReq;
-import com.manpowergroup.springboot.springboot3web.content.service.ArticleService;
-import com.manpowergroup.springboot.springboot3web.content.vo.ArticleVo;
+import com.manpowergroup.springboot.springboot3web.content.application.dto.ArticleCreateReq;
+import com.manpowergroup.springboot.springboot3web.content.application.dto.ArticleQueryRequest;
+import com.manpowergroup.springboot.springboot3web.content.application.dto.ArticleUpdateReq;
+import com.manpowergroup.springboot.springboot3web.content.application.service.ArticleService;
+import com.manpowergroup.springboot.springboot3web.content.application.vo.ArticleVo;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
### Motivation
- Decouple application logic from persistence by introducing a domain repository abstraction for `Article` and restricting MyBatis usage to the infrastructure layer. 
- Prevent application/service classes from depending directly on MyBatis mappers and clarify responsibilities following the `system` module DDD reference. 
- Make DTO/VO types belong to the application layer so domain remains free of transport concerns. 

### Description
- Moved the `Article` entity into `com.manpowergroup.springboot.springboot3web.content.domain.model.Article` and retained MyBatis annotations for persistence mapping. 
- Added a domain repository interface `com.manpowergroup.springboot.springboot3web.content.domain.repository.ArticleRepository` declaring required data operations used by the application layer. 
- Introduced `MybatisArticleRepository` (`com.manpowergroup.springboot.springboot3web.content.infrastructure.repository.MybatisArticleRepository`) as the infrastructure implementation that delegates to the MyBatis mapper. 
- Renamed/relocated the mapper to `com.manpowergroup.springboot.springboot3web.content.infrastructure.mapper.ArticleMapper` and updated `src/main/resources/mapper/ArticleMapper.xml` to reference the new mapper namespace and application `VO`/domain `Article` types. 
- Moved DTOs/VO (`ArticleCreateReq`, `ArticleUpdateReq`, `ArticleQueryRequest`, `ArticleVo`) to `content.application.dto` / `content.application.vo` and moved service interface + impl to `content.application.service` / `content.application.service.impl`. 
- Reworked `ArticleServiceImpl` to use constructor injection of `ArticleRepository` and removed direct use of `ArticleMapper` / MyBatis `baseMapper`, while preserving original business logic and return conventions. 
- Updated portal controller imports to use the new `application` package types. 

### Testing
- Ran `git diff --check` to ensure there are no whitespace/patch errors, which completed successfully. 
- Attempted `mvn -pl blog-module-content,blog-portal-api -am test -DskipTests=false`, but the Maven build could not complete in this environment due to inability to download `org.springframework.boot:spring-boot-starter-parent:3.4.9` from Maven Central (HTTP 403), so automated test execution/compilation could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb9c0f947483258b18560e130a8f51)