### PR TITLE
Add MenuController create WebMvc tests

### DIFF
--- a/blog-admin-api/src/test/java/com/manpowergroup/springboot/springboot3web/admin/MenuControllerTest.java
+++ b/blog-admin-api/src/test/java/com/manpowergroup/springboot/springboot3web/admin/MenuControllerTest.java
@@ -3,9 +3,11 @@ package com.manpowergroup.springboot.springboot3web.admin;
 import com.manpowergroup.springboot.springboot3web.blog.common.enums.ErrorCode;
 import com.manpowergroup.springboot.springboot3web.blog.common.exception.BizException;
 import com.manpowergroup.springboot.springboot3web.framework.handler.GlobalExceptionHandler;
+import com.manpowergroup.springboot.springboot3web.system.application.dto.menu.MenuSaveOrUpdateRequest;
 import com.manpowergroup.springboot.springboot3web.system.application.service.MenuAppService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -19,8 +21,11 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Locale;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -89,6 +94,13 @@ class MenuControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("success.ok"))
                 .andExpect(jsonPath("$.data").value(100L));
+
+        ArgumentCaptor<MenuSaveOrUpdateRequest> requestCaptor = ArgumentCaptor.forClass(MenuSaveOrUpdateRequest.class);
+        verify(menuAppService).createMenu(requestCaptor.capture());
+        MenuSaveOrUpdateRequest capturedRequest = requestCaptor.getValue();
+        assertThat(capturedRequest.name()).isEqualTo("メニュー管理");
+        assertThat(capturedRequest.path()).isEqualTo("/system/menu");
+        assertThat(capturedRequest.permission()).isEqualTo("sys:menu:list");
     }
 
     @Test
@@ -101,6 +113,8 @@ class MenuControllerTest {
                 .andExpect(jsonPath("$.message").value("error.validation"))
                 .andExpect(jsonPath("$.data.errors[?(@.field=='name')]").exists())
                 .andExpect(jsonPath("$.data.errors[?(@.field=='status')]").exists());
+
+        verify(menuAppService, never()).createMenu(any());
     }
 
     @Test
@@ -116,5 +130,7 @@ class MenuControllerTest {
                 .andExpect(jsonPath("$.code").value(500))
                 .andExpect(jsonPath("$.message").value("error.server"))
                 .andExpect(jsonPath("$.detail").value("メニュー作成に失敗しました"));
+
+        verify(menuAppService).createMenu(any());
     }
 }


### PR DESCRIPTION
### Motivation
- Provide focused controller-slice tests for the `create` endpoint using `@WebMvcTest(MenuController.class)` and `MockMvc` to validate request handling.
- Ensure request validation and business errors are translated by the existing `GlobalExceptionHandler` without modifying production code.
- Improve confidence that the controller forwards a correctly mapped `MenuSaveOrUpdateRequest` to the `MenuAppService`.

### Description
- Added assertions to the create-success test to capture the `MenuSaveOrUpdateRequest` passed to `MenuAppService#createMenu` and assert key fields are mapped from the JSON body.
- Added verification that validation failures short-circuit and the service is not invoked using `verify(..., never())`.
- Added verification that a thrown `BizException` from `MenuAppService` is translated to the expected error response and that the service was invoked.
- Changes are limited to the test file `blog-admin-api/src/test/java/com/manpowergroup/springboot/springboot3web/admin/MenuControllerTest.java` and do not modify any production code.

### Testing
- Ran `mvn -pl blog-admin-api -Dtest=MenuControllerTest test`, which could not complete in this environment because Maven failed to download the parent Spring Boot POM (`org.springframework.boot:spring-boot-starter-parent:3.4.9`) from Maven Central and returned HTTP 403, so tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc0330eafc8325aef0b123f8b191a2)