### PR TITLE
test(blog-admin-api): add MenuController integration test and TestApplication

### DIFF
--- a/blog-admin-api/pom.xml
+++ b/blog-admin-api/pom.xml
@@ -35,5 +35,10 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/blog-admin-api/src/test/java/com/manpowergroup/springboot/springboot3web/admin/MenuControllerIntegrationTest.java
+++ b/blog-admin-api/src/test/java/com/manpowergroup/springboot/springboot3web/admin/MenuControllerIntegrationTest.java
@@ -1,0 +1,76 @@
+package com.manpowergroup.springboot.springboot3web.admin;
+
+import com.manpowergroup.springboot.springboot3web.framework.security.jwt.JwtTokenProvider;
+import com.manpowergroup.springboot.springboot3web.system.application.service.LoginAppService;
+import com.manpowergroup.springboot.springboot3web.system.application.service.MenuAppService;
+import com.manpowergroup.springboot.springboot3web.system.application.service.PermissionAppService;
+import com.manpowergroup.springboot.springboot3web.system.application.service.RoleAppService;
+import com.manpowergroup.springboot.springboot3web.system.application.service.UserAppService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = TestApplication.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MenuControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MenuAppService menuAppService;
+
+    @MockBean
+    private LoginAppService loginAppService;
+
+    @MockBean
+    private UserAppService userAppService;
+
+    @MockBean
+    private RoleAppService roleAppService;
+
+    @MockBean
+    private PermissionAppService permissionAppService;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @WithMockUser(authorities = "sys:menu:create")
+    void shouldCreateMenuSuccessfully() throws Exception {
+        when(menuAppService.createMenu(any())).thenReturn(100L);
+
+        mockMvc.perform(post("/api/system/menu")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "parentId": 0,
+                                  "name": "系统管理",
+                                  "path": "/system",
+                                  "component": "Layout",
+                                  "permission": "sys:menu:list",
+                                  "type": 1,
+                                  "sort": 1,
+                                  "icon": "system",
+                                  "status": 1
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data").value(100L));
+
+        verify(menuAppService).createMenu(any());
+    }
+}

--- a/blog-admin-api/src/test/java/com/manpowergroup/springboot/springboot3web/admin/TestApplication.java
+++ b/blog-admin-api/src/test/java/com/manpowergroup/springboot/springboot3web/admin/TestApplication.java
@@ -1,0 +1,17 @@
+package com.manpowergroup.springboot.springboot3web.admin;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+
+@SpringBootApplication(
+        scanBasePackages = "com.manpowergroup.springboot.springboot3web",
+        exclude = {
+                DataSourceAutoConfiguration.class,
+                DataSourceTransactionManagerAutoConfiguration.class,
+                HibernateJpaAutoConfiguration.class
+        }
+)
+public class TestApplication {
+}


### PR DESCRIPTION
### Motivation
- Add an integration test for `MenuController#create` that runs inside the `blog-admin-api` module without referencing the application class in `blog-starter` to respect multi-module boundaries.
- Provide a minimal test startup class that scans the project packages and avoids unwanted datasource/JPA autoconfiguration during tests.

### Description
- Add `TestApplication` under `blog-admin-api/src/test/java` with `@SpringBootApplication(scanBasePackages = "com.manpowergroup.springboot.springboot3web")` and exclude common datasource/JPA autoconfigurations to prevent DB auto-configuration during tests.
- Add `MenuControllerIntegrationTest` that uses `@SpringBootTest(classes = TestApplication.class)`, `@AutoConfigureMockMvc(addFilters = false)`, JUnit 5, `MockMvc`, and `@MockBean` for `MenuAppService` (and additional required beans) to mock application-layer dependencies.
- The integration test mocks `MenuAppService.createMenu` to return a `Long` and performs a `POST /api/system/menu` request, asserting HTTP 200 and that the response JSON contains `code=200` and `data=100L`.
- Add `spring-security-test` as a test-scoped dependency to `blog-admin-api/pom.xml` to support `@WithMockUser` in tests.

### Testing
- Attempted to run `mvn -pl blog-admin-api -am test -Dtest=MenuControllerIntegrationTest -Dsurefire.failIfNoSpecifiedTests=false`, but the run failed because Maven in this environment could not download the parent POM `org.springframework.boot:spring-boot-starter-parent:3.4.9` from Maven Central (HTTP 403), so the automated test did not complete.
- No further automated test runs succeeded in this environment due to the repository dependency resolution restriction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc15c5547883259f3f1aa9b93d6f72)